### PR TITLE
error_file and out_file paths

### DIFF
--- a/docs/features/app-declaration.md
+++ b/docs/features/app-declaration.md
@@ -34,8 +34,8 @@ Here is an example of JSON configuration file, let's call it processes.json:
     "script"     : "api.js",
     "instances"  : 4,
     "exec_mode"  : "cluster_mode",
-    "error_file" : "./examples/child-err.log",
-    "out_file"   : "./examples/child-out.log",
+    "error_file" : "./examples/child-err.log", // Relative path seems to fail
+    "out_file"   : "./examples/child-out.log", // Relative path seems to fail
     "pid_file"   : "./examples/child.pid"
   }]
 }


### PR DESCRIPTION
In attempting to set these values, I assumed that the pathnames were relative to the ~/.pm2 directory. Oddly, if I leave the path off altogether, my log file is placed relative to the ~/.pm/ directory, however, if I specify a path (either ./logs/pm2.log or ~/.pm2/logs/pm2.log) it fails saying that it cannot find that directory. The only way I was able to make this work was to specify an absolute path form the base.