### PR TITLE
Change max to 0

### DIFF
--- a/docs/features/cluster-mode.md
+++ b/docs/features/cluster-mode.md
@@ -14,7 +14,7 @@ The **cluster mode** allows networked Node.js applications (http(s)/tcp/udp serv
 To enable the **cluster mode**, just pass the -i <instances> option:
 
 ```bash
-$ pm2 start  app.js -i max
+$ pm2 start  app.js -i 0
 ```
 
 Or via a [js/yaml/json file](http://pm2.keymetrics.io/docs/usage/application-declaration/):
@@ -23,7 +23,7 @@ Or via a [js/yaml/json file](http://pm2.keymetrics.io/docs/usage/application-dec
 {
   "apps" : [{
     "script"    : "api.js",
-    "instances" : "max",
+    "instances" : 0,
     "exec_mode" : "cluster"
   }]
 }


### PR DESCRIPTION
I got a `[PM2][WARN] Deprecated, we recommend using 0 instead of max to indicate maximum of instances.` warning so I thought it would make sense to also change this in the docs