### PR TITLE
Document reloadEnv option in gracefulReload API function

### DIFF
--- a/docs/features/pm2-api.md
+++ b/docs/features/pm2-api.md
@@ -92,9 +92,11 @@ pm2.connect(function(err) {
 **`pm2.restart(process, errback)`** - Stops and restarts the process.  
 **`pm2.delete(process, errback)`** - Stops the process and removes it from pm2's list. The process will no longer be accessible by its `name`.
 **`pm2.reload(process, errback)`** - Zero-downtime rolling restart. At least one process will be kept running at all times as each instance is restarted individually. *Only works for scripts started in cluster mode. [See here for more details](http://pm2.keymetrics.io/docs/usage/pm2-doc-single-page/#reload-without-downtime).*  
-**`pm2.gracefulReload(process, errback)`** - Sends the process a shutdown message before initiating `reload`. [See here for more details](http://pm2.keymetrics.io/docs/usage/pm2-doc-single-page/#graceful-reload).
+**`pm2.gracefulReload(process, options, errback)`** - Sends the process a shutdown message before initiating `reload`. [See here for more details](http://pm2.keymetrics.io/docs/usage/pm2-doc-single-page/#graceful-reload).
 
 * `process` - Can either be the `name` as given in the `pm2.start` `options`, a process id, or the string "all" to indicate that all scripts should be restarted.
+* `options` - (Optional) An object with the following options:
+  * `updateEnv` - (Default: false) If true is passed in, pm2 will reload it's environment from process.env before reloading your process.
 * `errback(err, proc)`
 
 **`pm2.killDaemon(errback)`** - Kills the pm2 daemon (same as `pm2 kill`). Note that when the daemon is killed, all its processes are also killed. Also note that you still have to explicitly disconnect from the daemon even after you kill it.


### PR DESCRIPTION
Showing a trace of this option:

1. [`API.prototype.gracefulReload`](https://github.com/Unitech/pm2/blob/9d980e017f1b3d31ba6d02f93a852c1a6e5e4cb3/lib/API.js#L417)
1. [`that._operate('softReloadProcessId', process_name, opts, cb);`](https://github.com/Unitech/pm2/blob/9d980e017f1b3d31ba6d02f93a852c1a6e5e4cb3/lib/API.js#L433)
1. [`API.prototype._operate`](https://github.com/Unitech/pm2/blob/9d980e017f1b3d31ba6d02f93a852c1a6e5e4cb3/lib/API.js#L1210)
1. [`if (envs.updateEnv === true)`](https://github.com/Unitech/pm2/blob/9d980e017f1b3d31ba6d02f93a852c1a6e5e4cb3/lib/API.js#L1225-L1226)
1. [Update env logic if `updateEnv` option set](https://github.com/Unitech/pm2/blob/9d980e017f1b3d31ba6d02f93a852c1a6e5e4cb3/lib/API.js#L1265-L1274)