### PR TITLE
update sendDataToProcessId

### DIFF
--- a/docs/features/pm2-api.md
+++ b/docs/features/pm2-api.md
@@ -164,13 +164,14 @@ pm2-call.js:
 
 ```javascript
 pm2.connect(function() {
-  pm2.sendDataToProcessId({
+  pm2.sendDataToProcessId(id, {
     type : 'process:msg',
     data : {
       some : 'data',
       hello : true
     },
     id   : proc1.pm2_env.pm_id
+    topic: 'some topic'
   }, function(err, res) {
   });
 });


### PR DESCRIPTION
As @chrizz1001 said in [PM2 cluster communication is confusing](https://github.com/Unitech/pm2/issues/1271#issuecomment-185693169)
If using sendDataToProcessId as [send-message-to-process](http://pm2.abingoal.com/docs/usage/pm2-api/#send-message-to-process) says, we will get the following error because of the documentation of sendDataToProcessId function lacks pm2_id as the first argument.

```
PM2        | Time                 : Sun Oct 29 2017 21:12:48 GMT+0800 (CST)
PM2        | Cannot read property 'id' of null
PM2        | TypeError: Cannot read property 'id' of null
PM2        |     at God.sendDataToProcessId (/usr/local/lib/node_modules/pm2/lib/God/ActionMethods.js:657:22)
```

So I try to contribute to the doc.