### PR TITLE
Fix small error in cheatsheet

### DIFF
--- a/docs/features/quick-start.md
+++ b/docs/features/quick-start.md
@@ -102,7 +102,7 @@ pm2 monit              # Monitor all processes
 # Logs
 
 pm2 logs [--raw]       # Display all processes logs in streaming
-pm2 flush              # Empty all log file
+pm2 flush              # Empty all log files
 pm2 reloadLogs         # Reload all logs
 
 # Actions


### PR DESCRIPTION
Flush's description should say "Empty all log files" (as opposed to the singular file) similar to the way it's mentioned on the log-management page.