### PR TITLE
fix typo: default pid path

### DIFF
--- a/docs/features/pm2-api.md
+++ b/docs/features/pm2-api.md
@@ -68,7 +68,7 @@ pm2.connect(function(err) {
   * `output` - (Default: `"~/.pm2/logs/app_name-out.log"`) The path to a file to append stdout output to. Can be the same file as `error`.
   * `error` - (Default: `"~/.pm2/logs/app_name-error.err"`) The path to a file to append stderr output to. Can be the same file as `output`.
   * `logDateFormat` - The display format for log timestamps (eg "YYYY-MM-DD HH:mm Z"). The format is a [moment display format](http://momentjs.com/docs/#/displaying/).
-  * `pid` - (Default: `"~/.pm2/logs/~/.pm2/pids/app_name-id.pid"`) The path to a file to write the pid of the started process. The file will be overwritten. Note that the file is not used in any way by pm2 and so the user is free to manipulate or remove that file at any time. The file will be deleted when the process is stopped or the daemon killed.
+  * `pid` - (Default: `"~/.pm2/pids/app_name-id.pid"`) The path to a file to write the pid of the started process. The file will be overwritten. Note that the file is not used in any way by pm2 and so the user is free to manipulate or remove that file at any time. The file will be deleted when the process is stopped or the daemon killed.
   * `minUptime` - The minimum uptime of the script before it's considered successfully started. 
   * `maxRestarts` - The maximum number of times in a row a script will be restarted if it exits in less than `min_uptime`.
   * `maxMemoryRestart` - If sets and `script`'s memory usage goes about the configured number, pm2 restarts the `script`. Uses human-friendly suffixes: 'K' for kilobytes, 'M' for megabytes, 'G' for gigabytes', etc. Eg "150M".


### PR DESCRIPTION
as title
fix from `"~/.pm2/logs/~/.pm2/pids/app_name-id.pid"`
to `"~/.pm2/pids/app_name-id.pid"`