### PR TITLE
Make 12factor.net a link in Cluster Mode docs

### DIFF
--- a/docs/features/cluster-mode.md
+++ b/docs/features/cluster-mode.md
@@ -84,5 +84,5 @@ process.on('SIGINT', function() {
 
 Be sure your [**application is stateless**](http://pm2.keymetrics.io/docs/usage/specifics/#stateless-apps) meaning that no local data is stored in the process, for example sessions/websocket connections, session-memory and related. Use Redis, Mongo or other databases to share states between processes.
 
-Another resource on how to write efficient, production ready stateless application is The Twelve Factor Application manifesto: https://12factor.net/
+Another resource on how to write efficient, production ready stateless application is [The Twelve Factor Application manifesto](https://12factor.net/).
 


### PR DESCRIPTION
In the rendering at http://pm2.keymetrics.io/docs/usage/cluster-mode/, the URL isn't a link.  This changes that.