### PR TITLE
wrong filename for pm2 start config

### DIFF
--- a/docs/full.md
+++ b/docs/full.md
@@ -184,7 +184,7 @@ module.exports = {
 And start it easily:
 
 ```bash
-$ pm2 start process.yml
+$ pm2 start ecosystem.config.js
 ```
 
 Read more about application declaration [here](/docs/usage/application-declaration/).


### PR DESCRIPTION
I just started to get into pm2, but it looks like the filename there is wrong. On the other page (/docs/usage/application-declaration/) it also says `ecosystem.config.js`