### PR TITLE
Fix wrong cli parameter in source-map-support.md

### DIFF
--- a/docs/features/source-map-support.md
+++ b/docs/features/source-map-support.md
@@ -47,6 +47,6 @@ Else use [keymetrics.io](https://keymetrics.io/) to have a clean listing and not
 
 ### Disable source map support
 
-If you do not want PM2 to automatically support javascript source map you can use the option `--disable-source-map`.
+If you do not want PM2 to automatically support javascript source map you can use the option `--disable-source-map-support`.
 
 It can be done both via CLI and via JSON file.


### PR DESCRIPTION
Hello, I'm recently found an issue in the documentation about SourceMap Support:

Using the `--disable-source-map` option in the command line interface result in the error shown in below:

![image](https://user-images.githubusercontent.com/29622423/81380474-90682b80-913d-11ea-835e-dd703dfc21df.png)

And the right option should be `--disable-source-map-support`:

![image](https://user-images.githubusercontent.com/29622423/81380543-af66bd80-913d-11ea-9f79-687202abfd61.png)
