### PR TITLE
Update docs/features page

### DIFF
--- a/docs/features/quick-start.md
+++ b/docs/features/quick-start.md
@@ -183,7 +183,7 @@ module.exports = {
 And start it easily:
 
 ```bash
-$ pm2 start process.yml
+$ pm2 start ecosystem.config.js
 ```
 
 Read more about application declaration [here](/docs/usage/application-declaration/).
@@ -293,17 +293,3 @@ Learn how to do [clean stop and restart](http://pm2.keymetrics.io/docs/usage/sig
 Learn how to [deploy and update production applications easily](http://pm2.keymetrics.io/docs/usage/deployment/).
 
 Monitor your production applications with [Keymetrics](https://keymetrics.io/).
-
-## How to update PM2
-
-Install the latest pm2 version:
-
-```bash
-npm install pm2@latest -g
-```
-
-Then update the in-memory PM2 :
-
-```bash
-pm2 update
-```


### PR DESCRIPTION
Upon reading this page, I noticed there was a duplicate section on updating pm2.
Also I noticed the example for the ecosystem file showed commands to create a ecosystem.config.js but then referenced `process.yml` in the start up command which, while supported, is confusing as `process.yml` was not mentioned anywhere in the example.
These changes would address both those issues.