### PR TITLE
Update quick-start.md

### DIFF
--- a/docs/features/quick-start.md
+++ b/docs/features/quick-start.md
@@ -183,7 +183,7 @@ module.exports = {
 And start it easily:
 
 ```bash
-$ pm2 start process.yml
+$ pm2 start ecosystem.config.js
 ```
 
 Read more about application declaration [here](/docs/usage/application-declaration/).


### PR DESCRIPTION
The command above `pm2 ecosystem` will generate `ecosystem.config.js`, not `process.yml`.
It looks like a legacy description.