### PR TITLE
docs: update full.md

### DIFF
--- a/docs/full.md
+++ b/docs/full.md
@@ -184,7 +184,7 @@ module.exports = {
 And start it easily:
 
 ```bash
-$ pm2 start process.yml
+$ pm2 start ecosystem.config.js
 ```
 
 Read more about application declaration [here](/docs/usage/application-declaration/).


### PR DESCRIPTION
## Summary
Fix misguiding documentation.

`pm2 ecosystem` yields `ecosystem.config.js` not `processes.yml`.

The docs should be updated.

### As-is
```bash	```bash
$ pm2 start process.yml
```
### To-Be
```bash
$ pm2 start ecosystem.config.js
```	```