### PR TITLE
Update source-map-support.md

### DIFF
--- a/docs/features/source-map-support.md
+++ b/docs/features/source-map-support.md
@@ -47,6 +47,6 @@ Else use [keymetrics.io](https://keymetrics.io/) to have a clean listing and not
 
 ### Disable source map support
 
-If you do not want PM2 to automatically support javascript source map you can use the option `--disable-source-map`.
+If you do not want PM2 to automatically support javascript source map you can use the option `--disable-source-map-support`.
 
 It can be done both via CLI and via JSON file.


### PR DESCRIPTION
Using the previous option name returns:

> error: unknown option `--disable-source-map'

Corrected option name from "disable-source-map" to "disable-source-map-support", to match the CLI "pm2 -h" output.