### PR TITLE
Fix a broken link

### DIFF
--- a/docs/features/log-management.md
+++ b/docs/features/log-management.md
@@ -113,7 +113,7 @@ pm2 flush <api> # Clear the logs for the app with name/id matching <api>
 
 ## Size limited log rotation
 
-You can also install [pm2-logrotate](http://pm2.keymetrics.io/docs/usage/log-management/#pm2-logrotate-module) to automatically rotate and keep all the logs file using a limited space on disk.
+You can also install [pm2-logrotate](https://github.com/keymetrics/pm2-logrotate) to automatically rotate and keep all the logs file using a limited space on disk.
 
 To install it:
 


### PR DESCRIPTION
It used to link to a separate section which linked to the GitHub page:
https://github.com/pm2-hive/pm2-hive.github.io/blob/9f9910e394e0ecfade613f82f5fa41c224e63433/docs/features/log-management.md#pm2-logrotate-module