### PR TITLE
Fix typo in environment.md

### DIFF
--- a/docs/features/environment.md
+++ b/docs/features/environment.md
@@ -83,7 +83,7 @@ In this case the variable will have the same behavior but will be in `process.en
 
 #### increment_var (PM2 2.5 minimum)
 
-There is an option to ask PM2 to increment a environment variable for each instance launched, for example:
+There is an option to ask PM2 to increment an environment variable for each instance launched, for example:
 
 ```javascript
 module.exports = {


### PR DESCRIPTION
For word that starts with a vowel sound the correct indefinite article is an