### PR TITLE
(docs/features/quick-start) doc: fix typo

### DIFF
--- a/docs/features/quick-start.md
+++ b/docs/features/quick-start.md
@@ -160,7 +160,7 @@ To generate an Ecosystem file:
 $ pm2 ecosystem
 ```
 
-This will generate and ecosystem.config.js file:
+This will generate an ecosystem.config.js file:
 
 ```javascript
 module.exports = {


### PR DESCRIPTION
changed **and** to **an**﻿
