### PR TITLE
Fix default log and pid filenames and add missing log_file option

### DIFF
--- a/docs/features/app-declaration.md
+++ b/docs/features/app-declaration.md
@@ -132,11 +132,12 @@ Application behavior and configuration can be fine-tuned with the following attr
 |    Field |   Type  |  Example |  Description|
 |:----------|:-------:|:------------------------------:|:-------------------------|
 |log_date_format| (string) | "YYYY-MM-DD HH:mm Z" | log date format (see log section)|
-|error_file| (string)| | error file path (default to $HOME/.pm2/logs/XXXerr.log)|
-|out_file| (string) | | output file path (default to $HOME/.pm2/logs/XXXout.log)|
+|error_file| (string)| | error file path (default to $HOME/.pm2/logs/&lt;app name&gt;-error-&lt;pid&gt;.log)|
+|out_file| (string) | | output file path (default to $HOME/.pm2/logs/&lt;app name&gt;-out-&lt;pid&gt;.log)|
+|log_file| (string) | | file path for both output and error logs (disabled by default)|
 |combine_logs| boolean | true | if set to true, avoid to suffix logs file with the process id |
 |merge_logs| boolean | true | alias to combine_logs |
-|pid_file| (string) | | pid file path (default to $HOME/.pm2/pid/app-pm_id.pid)|
+|pid_file| (string) | | pid file path (default to $HOME/.pm2/pids/&lt;app name&gt;-&lt;pid&gt;.pid)|
 
 ### Control flow
 

--- a/docs/features/log-management.md
+++ b/docs/features/log-management.md
@@ -113,9 +113,10 @@ Via configuration file you can pass the options:
 
 |    Field |   Type  |  Example |  Description|
 |:----------|:-------:|:------------------------------:|:-------------------------|
-|error_file| (string)| | error file path (default to $HOME/.pm2/logs/XXXerr.log)|
-|out_file| (string) | | output file path (default to $HOME/.pm2/logs/XXXout.log)|
-|pid_file| (string) | | pid file path (default to $HOME/.pm2/pid/app-pm_id.pid)|
+|error_file| (string)| | error file path (default to $HOME/.pm2/logs/&lt;app name&gt;-error-&lt;pid&gt;.log)|
+|out_file| (string) | | output file path (default to $HOME/.pm2/logs/&lt;app name&gt;-out-&lt;pid&gt;.log)|
+|log_file| (string) | | file path for both output and error logs (disabled by default)|
+|pid_file| (string) | | pid file path (default to $HOME/.pm2/pids/&lt;app name&gt;-&lt;pid&gt;.pid)|
 |merge_logs| boolean | true | if set to true, avoid to suffix logs file with the process id  |
 |log_date_format| (string) | "YYYY-MM-DD HH:mm Z" | log date format (see log section)|
 

--- a/docs/full.md
+++ b/docs/full.md
@@ -434,11 +434,12 @@ Application behavior and configuration can be fine-tuned with the following attr
 |    Field |   Type  |  Example |  Description|
 |:----------|:-------:|:------------------------------:|:-------------------------|
 |log_date_format| (string) | "YYYY-MM-DD HH:mm Z" | log date format (see log section)|
-|error_file| (string)| | error file path (default to $HOME/.pm2/logs/XXXerr.log)|
-|out_file| (string) | | output file path (default to $HOME/.pm2/logs/XXXout.log)|
+|error_file| (string)| | error file path (default to $HOME/.pm2/logs/&lt;app name&gt;-error-&lt;pid&gt;.log)|
+|out_file| (string) | | output file path (default to $HOME/.pm2/logs/&lt;app name&gt;-out-&lt;pid&gt;.log)|
+|log_file| (string) | | file path for both output and error logs (disabled by default)|
 |combine_logs| boolean | true | if set to true, avoid to suffix logs file with the process id |
 |merge_logs| boolean | true | alias to combine_logs |
-|pid_file| (string) | | pid file path (default to $HOME/.pm2/pid/app-pm_id.pid)|
+|pid_file| (string) | | pid file path (default to $HOME/.pm2/pids/&lt;app name&gt;-&lt;pid&gt;.pid)|
 
 ### Control flow
 
@@ -1218,9 +1219,10 @@ Via configuration file you can pass the options:
 
 |    Field |   Type  |  Example |  Description|
 |:----------|:-------:|:------------------------------:|:-------------------------|
-|error_file| (string)| | error file path (default to $HOME/.pm2/logs/XXXerr.log)|
-|out_file| (string) | | output file path (default to $HOME/.pm2/logs/XXXout.log)|
-|pid_file| (string) | | pid file path (default to $HOME/.pm2/pid/app-pm_id.pid)|
+|error_file| (string)| | error file path (default to $HOME/.pm2/logs/&lt;app name&gt;-error-&lt;pid&gt;.log)|
+|out_file| (string) | | output file path (default to $HOME/.pm2/logs/&lt;app name&gt;-out-&lt;pid&gt;.log)|
+|log_file| (string) | | file path for both output and error logs (disabled by default)|
+|pid_file| (string) | | pid file path (default to $HOME/.pm2/pids/&lt;app name&gt;-&lt;pid&gt;.pid)|
 |merge_logs| boolean | true | if set to true, avoid to suffix logs file with the process id  |
 |log_date_format| (string) | "YYYY-MM-DD HH:mm Z" | log date format (see log section)|
 


### PR DESCRIPTION
Fix default log and pid filenames:
* `error_file`:  `XXXerr.log` -> `<app name>-error-<pid>.log`
* `out_file`: `XXXout.log` -> `<app name>-out-<pid>.log`
* `pid_file`: `pid/app-pm_id.pid` -> `pids/<app name>-<pid>.pid`

Also add missing `log_file` option for combined logs.