### PR TITLE
Update update-pm2.md: suggest backup

### DIFF
--- a/docs/features/update-pm2.md
+++ b/docs/features/update-pm2.md
@@ -9,6 +9,8 @@ permalink: /docs/usage/update-pm2/
 
 Updating PM2 is extremely fast (less than few seconds) and seamless.
 
+You may wish to backup the `$HOME/.pm2/dump.pm2` file before performing an update, which will in turn back up your current processes.
+
 ### Process to update PM2
 
 Install the latest PM2 version:


### PR DESCRIPTION
Hi!

Not thinking, I updated PM2 using a remote terminal that runs via PM2. Therefore, when I used `pm2 update` it started to delete all the processes for the update, and once the web server was deleted, the update process stopped and left only 3 of my processes running. I SSHed on and the pm2.dump still had all my old processes - great! Stupidly, I ran `pm2 update` again, which wiped them and saved the 3 processes in pm2.dump instead.

I don't think it is unreasonable to suggest a backup may be wished before updating. But, perhaps you reckon no one can be that silly when updating, in which case you can leave it out 🤣

Many thanks
Eddie