### PR TITLE
Update deployment.md

### DIFF
--- a/docs/features/deployment.md
+++ b/docs/features/deployment.md
@@ -185,3 +185,14 @@ Host deployment
 # git@deployment:username/anyrepo.git
 # This is for cloning any repo that uses that IdentityFile. This is a good way to make sure that your remote cloning commands use the appropriate key
 ```
+Or, if you configure ssh-agent, it might be possible to solve it.
+Configure your local ~/.ssh/config as follows
+```
+# ~/.ssh/config
+Host deployment server ip address
+  ForwardAgent yes
+```
+Then run the command below
+```bash
+$ ssh-add ~/.ssh/id_rsa # your local private key
+```


### PR DESCRIPTION
When deploying to ec2, I was unable to resolve SSH clone errors described in step3.
I was able to solve the problem by adding ssh-agent.
So, I added ssh-agent configure examples in the troubleshooting column.