### PR TITLE
docs: fix typo in startup script generation instructions

### DIFF
--- a/docs/features/startup.md
+++ b/docs/features/startup.md
@@ -20,7 +20,7 @@ These init systems are automatically detected by PM2 with the `pm2 startup` comm
 
 ### Generating a Startup Script
 
-To automatically generate and configuration a startup script just type the command (without sudo) `pm2 startup`:
+To automatically generate and configure a startup script just type the command (without sudo) `pm2 startup`:
 
 ```bash
 $ pm2 startup


### PR DESCRIPTION
This PR replaces `configuration` with `configure `in the documentation.

<img width="1045" height="218" alt="image" src="https://github.com/user-attachments/assets/2f99f317-1345-46b2-a31e-7507bc00ad11" />
